### PR TITLE
No folder attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,6 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
 # Ignore Folder Attributes
+Thumbs.db
+Thumbs.db.meta
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Ignore Folder Attributes
+.DS_Store


### PR DESCRIPTION
Added .DS_Store and Thumb.db and Thumb.db.meta files. These files are created by the OS to store thumbnail information for displaying files in a finder, but are unnecessary in a GitHub repository.